### PR TITLE
[Fix] Prevent both user to use same symbol

### DIFF
--- a/app/main.rb
+++ b/app/main.rb
@@ -12,11 +12,11 @@ board = Board.new
 board.show
 # Set name and symbol for players
 player1 = Player.new
-player1.fetch_name
-player1.fetch_symbol('X')
 player2 = Player.new
+player1.fetch_name
+player1.fetch_symbol('X', player2.game_symbol)
 player2.fetch_name
-player2.fetch_symbol('O')
+player2.fetch_symbol('O', player1.game_symbol)
 
 # Start Play and get input from user
 game = Game.new(player1, player2, board)

--- a/app/player.rb
+++ b/app/player.rb
@@ -9,9 +9,13 @@ class Player
     @name = STDIN.gets.chomp
   end
 
-  def fetch_symbol(default)
+  def fetch_symbol(default, another_player_symbol = nil)
     puts "Please choose the prefered symbol. default will be #{default}:"
-    input_symbol = STDIN.gets.chomp
+    input_symbol = STDIN.gets.chomp.upcase
     @game_symbol = input_symbol.empty? ? default : input_symbol
+    while @game_symbol == another_player_symbol || @game_symbol.empty?
+      puts "Symbol '#{@game_symbol}' is either invalid or has been selected by another user. \nPlease enter another symbol"
+      @game_symbol = STDIN.gets.chomp.upcase
+    end
   end
 end

--- a/spec/app/player_spec.rb
+++ b/spec/app/player_spec.rb
@@ -16,7 +16,7 @@ describe Player do
 
   describe '#fetch_symbol' do
     let(:default_symbol) { 'X' }
-    let(:user_symbol) { 'Sym' }
+    let(:user_symbol) { 'Sym'.upcase }
     subject(:fetch_symbol) { player.fetch_symbol(default_symbol) }
 
     it 'takes string input as a symbol for player' do


### PR DESCRIPTION
When both users use the same symbol application does not work as expected as while checking the winning condition user symbol has been used.

Solution:
This fix does not allow any user to use the blank and the same symbol as another one.